### PR TITLE
Fixes broken `/projects/<id:int>/locations` route

### DIFF
--- a/api/src/models.py
+++ b/api/src/models.py
@@ -110,14 +110,18 @@ class Location(db.Model):
                'location={self.location}, '\
                'project_id={self.project_id})'.format(self=self)
 
+    @property 
+    def as_geojson(self):
+        return json.loads(
+            db.session.scalar(func.ST_AsGeoJSON(self.location))
+        )
+
     @property
     def coords(self):
         try:
-            geojson = json.loads(
-                db.session.scalar(func.ST_AsGeoJSON(self.location))
-            )
+            geojson = self.as_geojson
             assert geojson.get('type') == 'Point'
         except (TypeError, AssertionError):
             return {'longitude': None, 'latitude': None}
-
+        
         return dict(zip(('longitude', 'latitude'), geojson.get('coordinates')))

--- a/api/src/models.py
+++ b/api/src/models.py
@@ -110,6 +110,17 @@ class Location(db.Model):
                'location={self.location}, '\
                'project_id={self.project_id})'.format(self=self)
 
+
+    @property
+    def json(self):
+        return {
+            'address': self.address,
+            'city': self.city,
+            'state': self.state,
+            'zip_code': self.zip_code,
+            **self.coords
+        }
+
     @property 
     def as_geojson(self):
         return json.loads(

--- a/api/src/resources/projects.py
+++ b/api/src/resources/projects.py
@@ -85,7 +85,7 @@ class ProjectLocationsAPI(Resource):
 
     def get(self, id):
         project = Project.query.get(id)
-        return {"locations": [ loc.coords for loc in project.locations]}
+        return {"locations": [loc.json for loc in project.locations]}
 
 
 api.add_resource(

--- a/api/src/resources/projects.py
+++ b/api/src/resources/projects.py
@@ -85,7 +85,7 @@ class ProjectLocationsAPI(Resource):
 
     def get(self, id):
         project = Project.query.get(id)
-        return {"locations": [loc.json for loc in project.locations]}
+        return {"locations": [ loc.coords for loc in project.locations]}
 
 
 api.add_resource(

--- a/api/src/services/location_marker.py
+++ b/api/src/services/location_marker.py
@@ -51,9 +51,8 @@ class LatLng(LatLngNT):
     @property
     def json(self):
         return {
-            # 5 seems like a good number of sig digits: see --> https://gis.stackexchange.com/a/8674
-            'lat': round(self.lat, 5),
-            'lng': round(self.lng, 5)
+            'lat': self.lat,
+            'lng': self.lng
         }
 
 

--- a/api/src/services/location_marker.py
+++ b/api/src/services/location_marker.py
@@ -51,8 +51,9 @@ class LatLng(LatLngNT):
     @property
     def json(self):
         return {
-            'lat': self.lat,
-            'lng': self.lng
+            # 5 seems like a good number of sig digits: see --> https://gis.stackexchange.com/a/8674
+            'lat': round(self.lat, 5),
+            'lng': round(self.lng, 5)
         }
 
 
@@ -103,13 +104,14 @@ def aggregate_project_group(name, group):
 
 def compute_centroid(points):
     points = list(points)
-    if len(points) == 0:
+    n = len(points)
+    if n == 0:
         return None
     try:
         lat = sum(p.lat for p in points)
-        lat /= len([p for p in points])
+        lat /= n
         lng = sum(p.lng for p in points)
-        lng /= len([p for p in points])
+        lng /= n
         return LatLng(lat=lat, lng=lng)
     except ZeroDivisionError as e:
         return None


### PR DESCRIPTION
Fixes the `projects/<id:int>/locations` route so latlons don't return `NULL` values. This was because the lat/lons were being returned as WKB points.

Instead of:

![image](https://user-images.githubusercontent.com/25254995/88014768-56c08300-cae5-11ea-8d2b-807237490e75.png)

We now have:

![image](https://user-images.githubusercontent.com/25254995/88016902-1adbec80-caea-11ea-8322-8844af6b0f47.png)

I added in the extra values. That can be easily changed by changing the line in [`/api/src/resources/projects.py`](https://github.com/chris-french/meep-backend/blob/d293e740569e66b42e0ff3381015ed792cdaa138/api/src/resources/projects.py#L88) from

```python
return {"locations": [loc.json for loc in project.locations]}
```

to 

```python
return {"locations": [loc.coords for loc in project.locations]}
```

I also added [`as_geojson`](https://github.com/chris-french/meep-backend/blob/cf9c5866b10eaf80d8ba154ae3b1dce7883aac27/api/src/models.py#L114) as a class property to the [`Location`](https://github.com/chris-french/meep-backend/blob/cf9c5866b10eaf80d8ba154ae3b1dce7883aac27/api/src/models.py#L94) model.

Also, I made a minor tweak to the [`computer_centroid`](https://github.com/chris-french/meep-backend/blob/cf9c5866b10eaf80d8ba154ae3b1dce7883aac27/api/src/services/location_marker.py#L105) method. Much of this file seems redundant -- it maybe be worthwhile to either:

- Replace much of this code with the `Point` and `MultiPoint` classes from a library like [Shapely](https://shapely.readthedocs.io/en/latest/manual.html). 
- Or, perform all these calculations in PostGIS/SpatiaLite.

Also, maybe the output should be standardized? I.e., have it always return GeoJSON?
